### PR TITLE
Add sentry rake to notify sentry the new release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,36 @@
+PATH
+  remote: .
+  specs:
+    capistrano-sentry (0.1.0)
+      json
+      rest-client
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    json (2.1.0)
+    mime-types (2.99.3)
+    netrc (0.11.0)
+    rake (10.5.0)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.16)
+  capistrano-sentry!
+  rake (~> 10.0)
+
+BUNDLED WITH
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -30,38 +30,32 @@ You need to setup the `organization`, `projects` and `sha version` you want to a
 [Here](https://docs.sentry.io/api/auth/)
 
 
-### Setting in your deploy.rb
+### Setting in your environment in staging and production
 
 
-```
-
-# In deploy.rb
-
-set: :sentry_organization, 'your organization name' 
-set: :sentry_token, 'the token you get from last section'
-set: :branch_tag, 'the branch tag in the release'
-```
-
-You may have staging project and production project in sentry. 
-So you need to configure the projects name in different name. 
+You need to configure the projects name in different environment.
 
 ```ruby
 
-# In staging.rb
+# In config/deploy/staging.rb
 
 set: :sentry_projects, ['your first project', 'your second project']
+set: :sentry_organization, 'your organization name' 
+set: :sentry_token, 'the token you get from last section'
+set: :branch_tag, `git describe --tags`
 
 # current version name will append after your branch name 
 set: :current_version, `git rev-parse HEAD`.strip
 
 ```
 
+Please set the same setting in your `config/deploy/production.rb` 
+
 The `current_version` help you differ diffferent deployment in the staging enviornement 
 like 
 
 `release/2.0-sha1`
 `release/2.0-sha2`
-
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # Capistrano::Sentry
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/capistrano/sentry`. To experiment with that code, run `bin/console` for an interactive prompt.
+It's a callback to sentry application after every deployment you have. 
 
-TODO: Delete this and the text above, and describe your gem
+please check the [reference](https://docs.sentry.io/learn/releases/)
+
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'capistrano-sentry'
+gem 'capistrano-sentry', github: 'git@github.com:resumecompanion/capistrano-sentry.git'
 ```
 
 And then execute:
@@ -22,13 +23,46 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+You need to setup the `organization`, `projects` and `sha version` you want to append after the branch name 
 
-## Development
+### Get token from sentry 
 
-After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+[Here](https://docs.sentry.io/api/auth/)
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+### Setting in your deploy.rb
+
+
+```
+
+# In deploy.rb
+
+set: :sentry_organization, 'your organization name' 
+set: :sentry_token, 'the token you get from last section'
+set: :branch_tag, 'the branch tag in the release'
+```
+
+You may have staging project and production project in sentry. 
+So you need to configure the projects name in different name. 
+
+```ruby
+
+# In staging.rb
+
+set: :sentry_projects, ['your first project', 'your second project']
+
+# current version name will append after your branch name 
+set: :current_version, `git rev-parse HEAD`.strip
+
+```
+
+The `current_version` help you differ diffferent deployment in the staging enviornement 
+like 
+
+`release/2.0-sha1`
+`release/2.0-sha2`
+
+
 
 ## Contributing
 

--- a/capistrano-sentry.gemspec
+++ b/capistrano-sentry.gemspec
@@ -10,9 +10,9 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Alan Yu"]
   spec.email         = ["alan21120000@gmail.com"]
 
-  spec.summary       = %q{TODO: Write a short summary, because RubyGems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.summary       = %q{Webhook to sentry after deploy published hook}
+  spec.description   = %q{Webhook to sentry after deploy published hook}
+  spec.homepage      = "http://www.google.com"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
@@ -33,4 +33,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_dependency "rest-client"
+  spec.add_dependency 'json'
 end

--- a/lib/capistrano/sentry.rb
+++ b/lib/capistrano/sentry.rb
@@ -1,4 +1,5 @@
 require "capistrano/sentry/version"
+load File.expand_path('../tasks/notify_sentry.rake', __FILE__)
 
 module Capistrano
   module Sentry

--- a/lib/capistrano/tasks/notify_sentry.rake
+++ b/lib/capistrano/tasks/notify_sentry.rake
@@ -1,0 +1,29 @@
+require 'rest-client'
+require 'json'
+
+SENTRY_ENDPOINT = 'https://sentry.io/api/0/organizations/'.freeze
+
+namespace :sentry do
+  task :notify_deployment do
+    url = "#{SENTRY_ENDPOINT}#{fetch(:sentry_organization)}/releases/"
+    token = fetch(:sentry_token)
+    projects = fetch(:sentry_projects)
+
+    payload = { version: "#{fetch(:branch_tag).strip!}-#{fetch(:current_version)}",
+                projects: projects }
+
+    json_payload = JSON.generate(payload)
+
+    puts 'Notify Sentry Release start ....'
+
+    run_locally do
+      response = RestClient.post(url,
+                                 json_payload,
+                                 content_type: 'application/json', authorization: "Bearer #{token}")
+
+      puts "Sentry response: #{response.body}"
+    end
+  end
+
+  after 'deploy:publishing', :'sentry:notify_deployment'
+end


### PR DESCRIPTION
Requirement

For better error tracking between in sentry and our release versoin,

it's better to notify sentry in every deployment so sentry will know
which bug is generate from which version

Implementation

Expose the project organization and token to application