### PR TITLE
Fix the sentry deploy problem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    capistrano-sentry (0.1.0)
+    capistrano-sentry (0.1.1)
       json
       rest-client
 
@@ -12,17 +12,19 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    json (2.1.0)
-    mime-types (2.99.3)
+    json (2.0.4)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     netrc (0.11.0)
     rake (10.5.0)
-    rest-client (1.8.0)
+    rest-client (2.0.1)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.5)
+    unf_ext (0.0.7.2)
 
 PLATFORMS
   ruby
@@ -33,4 +35,4 @@ DEPENDENCIES
   rake (~> 10.0)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/lib/capistrano/sentry/version.rb
+++ b/lib/capistrano/sentry/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Sentry
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end

--- a/lib/capistrano/tasks/notify_sentry.rake
+++ b/lib/capistrano/tasks/notify_sentry.rake
@@ -19,13 +19,11 @@ namespace :sentry do
     run_locally do
       begin
         RestClient.post(url, json_payload,
-                        content_type: 'application/json', authorization: "Bearer #{token}") 
+                        content_type: 'application/json', authorization: "Bearer #{token}")
 
-        begin
-          puts "Sentry response: #{response.body}"
-        rescue StandardError => e
-          puts e.response
-        end
+        puts "Sentry response: #{response.body}"
+      rescue StandardError => e
+        puts e.response
       end
     end
   end

--- a/lib/capistrano/tasks/notify_sentry.rake
+++ b/lib/capistrano/tasks/notify_sentry.rake
@@ -17,11 +17,16 @@ namespace :sentry do
     puts 'Notify Sentry Release start ....'
 
     run_locally do
-      response = RestClient.post(url,
-                                 json_payload,
-                                 content_type: 'application/json', authorization: "Bearer #{token}")
+      begin
+        RestClient.post(url, json_payload,
+                        content_type: 'application/json', authorization: "Bearer #{token}") 
 
-      puts "Sentry response: #{response.body}"
+        begin
+          puts "Sentry response: #{response.body}"
+        rescue StandardError => e
+          puts e.response
+        end
+      end
     end
   end
 

--- a/lib/capistrano/tasks/notify_sentry.rake
+++ b/lib/capistrano/tasks/notify_sentry.rake
@@ -18,12 +18,13 @@ namespace :sentry do
 
     run_locally do
       begin
-        RestClient.post(url, json_payload,
-                        content_type: 'application/json', authorization: "Bearer #{token}")
+        response = RestClient.post(url, json_payload,
+                                   content_type: 'application/json',
+                                   authorization: "Bearer #{token}")
 
         puts "Sentry response: #{response.body}"
       rescue StandardError => e
-        puts e.response
+        puts e
       end
     end
   end


### PR DESCRIPTION
Bug

The sentry hook will notify sentry to create a new release version,

sometimes we will deploy same version of code which sentry will return
408 already reported for us

Fix

Ignore all the response only note in logger, because we don't want to
this failed task break all of the deployment